### PR TITLE
Various refactorings and fixes:

### DIFF
--- a/include/macros.h
+++ b/include/macros.h
@@ -32,6 +32,8 @@
 #define LINK_IS_ADULT (gSaveContext.save.linkAge == LINK_AGE_ADULT)
 #define LINK_IS_CHILD (gSaveContext.save.linkAge == LINK_AGE_CHILD)
 
+#define LINK_AGE_VALUE(adult, child) (LINK_IS_ADULT ? (adult) : (child))
+
 #define YEARS_CHILD 5
 #define YEARS_ADULT 17
 #define LINK_AGE_IN_YEARS (!LINK_IS_ADULT ? YEARS_CHILD : YEARS_ADULT)

--- a/include/z64player.h
+++ b/include/z64player.h
@@ -140,7 +140,13 @@ typedef enum {
     /* 0x43 */ PLAYER_IA_MAX
 } PlayerItemAction;
 
-#define IS_LIMB(index, adult, child) ((index) == (LINK_IS_ADULT ? (adult) : (child)))
+// Use 'MAX' when you want the max number of limbs for the current age.
+// Use 'ARR_COUNT' when you want the max number of limbs for all ages.
+#define PLAYER_LIMB_MAX LINK_AGE_VALUE(PLAYER_ADULT_LIMB_MAX, PLAYER_WOLF_LIMB_MAX)
+#define PLAYER_LIMB_ARR_COUNT MAX((s16)PLAYER_ADULT_LIMB_MAX, (s16)PLAYER_WOLF_LIMB_MAX)
+
+#define LIMB_BUF_COUNT(limbCount) ((ALIGN16((limbCount) * sizeof(Vec3s)) + sizeof(Vec3s) - 1) / sizeof(Vec3s))
+#define PLAYER_LIMB_BUF_COUNT LIMB_BUF_COUNT(PLAYER_LIMB_ARR_COUNT)
 
 typedef enum {  // look at sUpperBodyLimbCopyMap
     /* 0x00 */ PLAYER_ADULT_LIMB_NONE,
@@ -199,6 +205,11 @@ typedef enum {  // look at sUpperBodyLimbCopyMap
     /* 0x1B */ PLAYER_WOLF_LIMB_R_PAD, // R_HAND
     /* 0x1C */ PLAYER_WOLF_LIMB_MAX // MAX
 } PlayerWolfLimb;
+
+// Use 'MAX' when you want the max number of body parts for the current age.
+// Use 'ARR_COUNT' when you want the max number of body parts for all ages.
+#define PLAYER_BODYPART_MAX LINK_AGE_VALUE(PLAYER_ADULT_BODYPART_MAX, PLAYER_WOLF_BODYPART_MAX)
+#define PLAYER_BODYPART_ARR_COUNT MAX((s16)PLAYER_ADULT_BODYPART_MAX, (s16)PLAYER_WOLF_BODYPART_MAX)
 
 typedef enum {
     /* 0x00 */ PLAYER_ADULT_BODYPART_WAIST,         // PLAYER_LIMB_WAIST // used for a lof ot positioning behaviours with camera, fairies, thunder actor, water ripples etc.
@@ -412,9 +423,6 @@ typedef enum {
     /* 0x2C */ PLAYER_ANIMGROUP_nwait,
     /* 0x2D */ PLAYER_ANIMGROUP_MAX
 } PlayerAnimGroup;
-
-#define LIMB_BUF_COUNT(limbCount) ((ALIGN16((limbCount) * sizeof(Vec3s)) + sizeof(Vec3s) - 1) / sizeof(Vec3s))
-#define PLAYER_LIMB_BUF_COUNT LIMB_BUF_COUNT(PLAYER_WOLF_LIMB_MAX)
 
 typedef enum {
     /* 0x00 */ PLAYER_CSACTION_NONE,

--- a/mod_assets/objects/mod_gameplay_keep/mod_gameplay_keep.c
+++ b/mod_assets/objects/mod_gameplay_keep/mod_gameplay_keep.c
@@ -5,7 +5,7 @@
 #include "assets/misc/wolf_animetion/wolf_animetion.h"
 
 LinkAnimationHeader gPlayerAnim_wolf_normal_temp = {
-	{ 90 }, gPlayerAnim_wolf_normal_tempData 
+	{ 55 }, gPlayerAnim_wolf_normal_tempData
 };
 
 LinkAnimationHeader gPlayeranim_wolf_normal_walk = {

--- a/mod_assets/objects/object_link_child/object_link_child.c
+++ b/mod_assets/objects/object_link_child/object_link_child.c
@@ -93,6 +93,8 @@ u64 gLinkChildBeltClaspTex[] = {
 #include "assets/objects/object_link_child/belt_clasp.ci8.inc.c"
 };
 
+// Vtx object_link_childVtx_006A80[] = { ... }
+
 u64 gLinkChildFairyOcarinaTex[] = {
 #include "assets/objects/object_link_child/fairy_ocarina.rgba16.inc.c"
 };
@@ -164,6 +166,18 @@ u64 gLinkChildMasterSwordEmblemTex[] = {
 Vtx object_link_childVtx_00ABF0[] = {
 #include "assets/objects/object_link_child/object_link_childVtx_00ABF0.vtx.inc"
 };
+
+// Vtx object_link_childVtx_018758[] = { ... }
+// Vtx object_link_childVtx_01A038[] = { ... }
+// Vtx object_link_childVtx_01A698[] = { ... }
+// Vtx object_link_childVtx_01AD18[] = { ... }
+// Vtx object_link_childVtx_01C978[] = { ... }
+// Vtx object_link_childVtx_01EDA8[] = { ... }
+// Vtx object_link_childVtx_01F528[] = { ... }
+// Vtx object_link_childVtx_01FE08[] = { ... }
+// Vtx object_link_childVtx_022148[] = { ... }
+// Vtx object_link_childVtx_022208[] = { ... }
+// Mtx gLinkChildDekuShieldMtx = { ... }
 
 u64 gLinkChildSpookyMaskTex[] = {
 #include "assets/objects/object_link_child/spooky_mask.ia16.inc.c"
@@ -249,6 +263,8 @@ u64 gLinkChildGerudoMaskNoseTex[] = {
 #include "assets/objects/object_link_child/gerudo_mask_nose.rgba16.inc.c"
 };
 
+// Vtx object_link_childVtx_029220[] = { ... }
+
 u64 gLinkChildBunnyHoodEyeTex[] = {
 #include "assets/objects/object_link_child/bunny_hood_eye.rgba16.inc.c"
 };
@@ -260,3 +276,5 @@ u64 gLinkChildBunnyHoodTex[] = {
 u64 gLinkChildBunnyHoodEarTex[] = {
 #include "assets/objects/object_link_child/bunny_hood_ear.rgba16.inc.c"
 };
+
+// Vtx object_link_childVtx_02C428[] = { ... }

--- a/mod_assets/objects/object_link_child/object_link_child.h
+++ b/mod_assets/objects/object_link_child/object_link_child.h
@@ -4,35 +4,49 @@
 #include "object_link_wolf.h"
 #include "Cube.h"
 
+extern u64 gLinkChildEyesOpenTex[];
+extern u64 gLinkChildEyesHalfTex[];
+extern u64 gLinkChildEyesClosedfTex[];
+extern u64 gLinkChildEyesRollLeftTex[];
+extern u64 gLinkChildEyesRollRightTex[];
+extern u64 gLinkChildEyesShockTex[];
+extern u64 gLinkChildEyesUnk1Tex[];
+extern u64 gLinkChildEyesUnk2Tex[];
+extern u64 gLinkChildMouth1Tex[];
+extern u64 gLinkChildMouth2Tex[];
+extern u64 gLinkChildMouth3Tex[];
+extern u64 gLinkChildMouth4Tex[];
+extern u64 gLinkChildNoseTex[];
+extern u64 gLinkChildUnusedHandTex[];
+extern u64 gLinkChildEarTex[];
+extern u64 gLinkChildBeltTLUT[];
+extern u64 gLinkChildSkinTLUT[];
+extern u64 gLinkChildLowerBootTex[];
+extern u64 gLinkChildUnusedBootTex[];
+extern u64 gLinkChildBootTex[];
+extern u64 gLinkChildWaistTex[];
+extern u64 gLinkChildBeltTex[];
+extern u64 gLinkChildBeltClaspTex[];
+extern Vtx object_link_childVtx_006A80[];
 #define gLinkChildLinkDekuStickDL Cube
-#define gLinkChildRightHandClosedNearDL Cube
-#define gLinkChildRightHandClosedFarDL Cube
-#define gLinkChildBunnyHoodDL Cube
-#define gLinkChildSkullMaskDL Cube
-#define gLinkChildSpookyMaskDL Cube
-#define gLinkChildKeatonMaskDL Cube
-#define gLinkChildMaskOfTruthDL Cube
-#define gLinkChildGoronMaskDL Cube
-#define gLinkChildZoraMaskDL Cube
-#define gLinkChildGerudoMaskDL Cube
-#define gLinkChildDekuShieldWithMatrixDL Cube
-#define gLinkChildDekuShieldDL Cube
-#define gLinkChildSlinghotStringDL Cube
-#define gLinkChildWaistNearDL Cube
-#define gLinkChildRightThighNearDL Cube
-#define gLinkChildRightShinNearDL Cube
-#define gLinkChildRightFootNearDL Cube
-#define gLinkChildLeftThighNearDL Cube
-#define gLinkChildLeftShinNearDL Cube
-#define gLinkChildLeftFootNearDL Cube
-#define gLinkChildCollarNearDL Cube
-#define gLinkChildTorsoNearDL Cube
-#define gLinkChildHeadNearDL Cube
-#define gLinkChildHatNearDL Cube
-#define gLinkChildRightShoulderNearDL Cube
-#define gLinkChildRightForearmNearDL Cube
-#define gLinkChildLeftShoulderNearDL Cube
-#define gLinkChildLeftForearmNearDL Cube
+extern u64 gLinkChildFairyOcarinaTex[];
+extern u64 gLinkChildGoronBraceletTex[];
+extern u64 gLinkChildGoronSymbolTex[];
+extern u64 gLinkChildDekuShieldBackTex[];
+extern u64 gLinkChildDekuShieldFrontTex[];
+extern u64 gLinkChildHylianShieldBackTex[];
+extern u64 gLinkChildSlingshotTex[];
+extern u64 gLinkChildSlingshotSeedTex[];
+extern u64 gLinkChildHandTLUT[];
+extern u64 gLinkChildSwordsTLUT[];
+extern u64 gLinkChildSwordTLUT[];
+extern u64 gLinkChildHandTex[];
+extern u64 gLinkChildKokiriSwordSheathTex[];
+extern u64 gLinkChildSwordJewelTex[];
+extern u64 gLinkChildMasterSwordPommelTex[];
+extern u64 gLinkChildMasterSwordGuardTex[];
+extern u64 gLinkChildMasterSwordEmblemTex[];
+extern Vtx object_link_childVtx_00ABF0[];
 #define gLinkChildLeftHandNearDL Cube
 #define gLinkChildLeftFistNearDL Cube
 #define gLinkChildLeftFistAndKokiriSwordNearDL Cube
@@ -71,7 +85,12 @@
 #define gLinkChildLeftHandUpFarDL Cube
 #define gLinkChildRightArmStretchedSlingshotDL Cube
 #define gLinkChildBottleDL Cube
-
+#define gLinkChildDL_18580 Cube
+#define gLinkChildBottle2DL Cube
+extern Vtx object_link_childVtx_018758[];
+extern Vtx object_link_childVtx_01A038[];
+extern Vtx object_link_childVtx_01A698[];
+extern Vtx object_link_childVtx_01AD18[];
 #define gLinkChildWaistFarDL Cube
 #define gLinkChildRightThighFarDL Cube
 #define gLinkChildRightShinFarDL Cube
@@ -87,77 +106,31 @@
 #define gLinkChildRightForearmFarDL Cube
 #define gLinkChildLeftShoulderFarDL Cube
 #define gLinkChildLeftForearmFarDL Cube
-
-extern u64 gLinkChildEyesOpenTex[];
-extern u64 gLinkChildEyesHalfTex[];
-extern u64 gLinkChildEyesClosedfTex[];
-extern u64 gLinkChildEyesRollLeftTex[];
-extern u64 gLinkChildEyesRollRightTex[];
-extern u64 gLinkChildEyesShockTex[];
-extern u64 gLinkChildEyesUnk1Tex[];
-extern u64 gLinkChildEyesUnk2Tex[];
-extern u64 gLinkChildMouth1Tex[];
-extern u64 gLinkChildMouth2Tex[];
-extern u64 gLinkChildMouth3Tex[];
-extern u64 gLinkChildMouth4Tex[];
-extern u64 gLinkChildNoseTex[];
-extern u64 gLinkChildUnusedHandTex[];
-extern u64 gLinkChildEarTex[];
-extern u64 gLinkChildBeltTLUT[];
-extern u64 gLinkChildSkinTLUT[];
-extern u64 gLinkChildLowerBootTex[];
-extern u64 gLinkChildUnusedBootTex[];
-extern u64 gLinkChildBootTex[];
-extern u64 gLinkChildWaistTex[];
-extern u64 gLinkChildBeltTex[];
-extern u64 gLinkChildBeltClaspTex[];
-extern Vtx object_link_childVtx_006A80[];
-extern u64 gLinkChildFairyOcarinaTex[];
-extern u64 gLinkChildGoronBraceletTex[];
-extern u64 gLinkChildGoronSymbolTex[];
-extern u64 gLinkChildDekuShieldBackTex[];
-extern u64 gLinkChildDekuShieldFrontTex[];
-extern u64 gLinkChildHylianShieldBackTex[];
-extern u64 gLinkChildSlingshotTex[];
-extern u64 gLinkChildSlingshotSeedTex[];
-extern u64 gLinkChildHandTLUT[];
-extern u64 gLinkChildSwordsTLUT[];
-extern u64 gLinkChildSwordTLUT[];
-extern u64 gLinkChildHandTex[];
-extern u64 gLinkChildKokiriSwordSheathTex[];
-extern u64 gLinkChildSwordJewelTex[];
-extern u64 gLinkChildMasterSwordPommelTex[];
-extern u64 gLinkChildMasterSwordGuardTex[];
-extern u64 gLinkChildMasterSwordEmblemTex[];
-extern Vtx object_link_childVtx_00ABF0[];
-extern Gfx gLinkChildDL_18580[];
-extern Gfx gLinkChildBottle2DL[];
-extern Vtx object_link_childVtx_018758[];
-extern Vtx object_link_childVtx_01A038[];
-extern Vtx object_link_childVtx_01A698[];
-extern Vtx object_link_childVtx_01AD18[];
-// extern Gfx gLinkChildWaistFarDL[];
-// extern Gfx gLinkChildRightThighFarDL[];
-// extern Gfx gLinkChildRightShinFarDL[];
-// extern Gfx gLinkChildRightFootFarDL[];
-// extern Gfx gLinkChildLeftThighFarDL[];
-// extern Gfx gLinkChildLeftShinFarDL[];
-// extern Gfx gLinkChildLeftFootFarDL[];
-// extern Gfx gLinkChildCollarFarDL[];
-// extern Gfx gLinkChildTorsoFarDL[];
-// extern Gfx gLinkChildHeadFarDL[];
-// extern Gfx gLinkChildHatFarDL[];
-// extern Gfx gLinkChildRightShoulderFarDL[];
-// extern Gfx gLinkChildRightForearmFarDL[];
-// extern Gfx gLinkChildLeftShoulderFarDL[];
-// extern Gfx gLinkChildLeftForearmFarDL[];
 extern Vtx object_link_childVtx_01C978[];
 extern Vtx object_link_childVtx_01EDA8[];
 extern Vtx object_link_childVtx_01F528[];
 extern Vtx object_link_childVtx_01FE08[];
+#define gLinkChildWaistNearDL Cube
+#define gLinkChildRightThighNearDL Cube
+#define gLinkChildRightShinNearDL Cube
+#define gLinkChildRightFootNearDL Cube
+#define gLinkChildLeftThighNearDL Cube
+#define gLinkChildLeftShinNearDL Cube
+#define gLinkChildLeftFootNearDL Cube
+#define gLinkChildCollarNearDL Cube
+#define gLinkChildTorsoNearDL Cube
+#define gLinkChildHeadNearDL Cube
+#define gLinkChildHatNearDL Cube
+#define gLinkChildRightShoulderNearDL Cube
+#define gLinkChildRightForearmNearDL Cube
+#define gLinkChildLeftShoulderNearDL Cube
+#define gLinkChildLeftForearmNearDL Cube
 extern Vtx object_link_childVtx_022148[];
+#define gLinkChildSlinghotStringDL Cube
 extern Vtx object_link_childVtx_022208[];
+#define gLinkChildDekuShieldDL Cube
 extern Mtx gLinkChildDekuShieldMtx;
+#define gLinkChildDekuShieldWithMatrixDL Cube
 extern u64 gLinkChildSpookyMaskTex[];
 extern u64 gLinkChildKeatonMaskEyeBrowTex[];
 extern u64 gLinkChildKeatonMaskEarTex[];
@@ -180,10 +153,18 @@ extern u64 gLinkChildGerudoMaskMouthTex[];
 extern u64 gLinkChildGerudoMaskHairTex[];
 extern u64 gLinkChildGerudoMaskNoseTex[];
 extern Vtx object_link_childVtx_029220[];
+#define gLinkChildSkullMaskDL Cube
+#define gLinkChildSpookyMaskDL Cube
+#define gLinkChildKeatonMaskDL Cube
+#define gLinkChildMaskOfTruthDL Cube
+#define gLinkChildGoronMaskDL Cube
+#define gLinkChildZoraMaskDL Cube
+#define gLinkChildGerudoMaskDL Cube
 extern u64 gLinkChildBunnyHoodEyeTex[];
 extern u64 gLinkChildBunnyHoodTex[];
 extern u64 gLinkChildBunnyHoodEarTex[];
 extern Vtx object_link_childVtx_02C428[];
+#define gLinkChildBunnyHoodDL Cube
 // extern LodLimb gLinkChildRootLimb;
 // extern LodLimb gLinkChildWaistLimb;
 // extern LodLimb gLinkChildLowerControlLimb;
@@ -206,5 +187,6 @@ extern Vtx object_link_childVtx_02C428[];
 // extern LodLimb gLinkChildSwordAndSheathLimb;
 // extern LodLimb gLinkChildTorsoLimb;
 // extern void* gLinkChildSkelLimbs[];
-// extern FlexSkeletonHeader gLinkChildSkel;
+#define gLinkChildSkel gLinkWolfSkel
+
 #endif

--- a/src/code/z_camera.c
+++ b/src/code/z_camera.c
@@ -4697,7 +4697,7 @@ s32 Camera_Unique1(Camera* camera) {
         camera->playerToAtOffset.y -= camera->playerPosDelta.y;
         rwData->yawTarget = eyeNextAtOffset.yaw;
         rwData->unk_00 = 0.0f;
-        playerWaistPos = camera->player->bodyPartsPos[PLAYER_ADULT_BODYPART_WAIST];
+        playerWaistPos = camera->player->bodyPartsPos[LINK_AGE_VALUE(PLAYER_ADULT_BODYPART_WAIST, PLAYER_WOLF_BODYPART_WAIST)];
         OLib_Vec3fDiffToVecGeo(&unk908PlayerPosOffset, &playerPosRot->pos, &playerWaistPos);
         rwData->timer = R_CAM_DEFAULT_ANIM_TIME;
         rwData->yawTargetAdj = ABS((s16)(unk908PlayerPosOffset.yaw - eyeAtOffset.yaw)) < 0x3A98

--- a/src/code/z_player_lib.c
+++ b/src/code/z_player_lib.c
@@ -1053,7 +1053,7 @@ s32 Player_OverrideLimbDrawGameplayCommon(PlayState* play, s32 limbIndex, Gfx** 
                                           void* thisx) {
     Player* this = (Player*)thisx;
 
-    if (IS_LIMB(limbIndex, PLAYER_ADULT_LIMB_ROOT, PLAYER_WOLF_LIMB_ROOT)) {
+    if (limbIndex == LINK_AGE_VALUE(PLAYER_ADULT_LIMB_ROOT, PLAYER_WOLF_LIMB_ROOT)) {
         sLeftHandType = this->leftHandType;
         sRightHandType = this->rightHandType;
 
@@ -1092,13 +1092,13 @@ s32 Player_OverrideLimbDrawGameplayCommon(PlayState* play, s32 limbIndex, Gfx** 
             sCurBodyPartPos++;
         }
 
-        if (IS_LIMB(limbIndex, PLAYER_ADULT_LIMB_HEAD, PLAYER_WOLF_LIMB_NECK)) {
+        if (limbIndex == LINK_AGE_VALUE(PLAYER_ADULT_LIMB_HEAD, PLAYER_WOLF_LIMB_NECK)) {
             // rotations based on Z-target? head looks at target
             // play with `rot->y` value to try and tilt it the other way, look at girl above kokiri shop
             rot->x += this->unk_6BA;
             rot->y -= this->unk_6B8;
             rot->z += this->unk_6B6;
-        } else if (IS_LIMB(limbIndex, PLAYER_ADULT_LIMB_UPPER, PLAYER_WOLF_LIMB_UPPER)) {
+        } else if (limbIndex == LINK_AGE_VALUE(PLAYER_ADULT_LIMB_UPPER, PLAYER_WOLF_LIMB_UPPER)) {
             // this is rotating link's upper body to blend the animation when running for ex
             if (this->unk_6B0 != 0) {
                 Matrix_RotateZ(BINANG_TO_RAD(0x44C), MTXMODE_APPLY);
@@ -1206,6 +1206,7 @@ s32 Player_OverrideLimbDrawGameplayFirstPerson(PlayState* play, s32 limbIndex, G
                                                void* thisx) {
     Player* this = (Player*)thisx;
 
+// TODO: Come back to this; not right for child
     if (!Player_OverrideLimbDrawGameplayCommon(play, limbIndex, dList, pos, rot, thisx)) {
         if (this->unk_6AD != 2) {
             *dList = NULL;
@@ -1476,7 +1477,7 @@ void Player_PostLimbDrawGameplay(PlayState* play, s32 limbIndex, Gfx** dList, Ve
         Matrix_MultVec3f(&sZeroVec, sCurBodyPartPos);
     }
 
-    if (limbIndex == PLAYER_ADULT_LIMB_L_HAND) {
+    if (limbIndex == LINK_AGE_VALUE(PLAYER_ADULT_LIMB_L_HAND, PLAYER_WOLF_LIMB_L_PAD)) {
         MtxF sp14C;
         Actor* hookedActor;
 
@@ -1555,7 +1556,7 @@ void Player_PostLimbDrawGameplay(PlayState* play, s32 limbIndex, Gfx** dList, Ve
                 Matrix_MtxFToYXZRotS(&this->mf_9E0, &this->unk_3BC, 0);
             }
         }
-    } else if (limbIndex == PLAYER_ADULT_LIMB_R_HAND) {
+    } else if (limbIndex == LINK_AGE_VALUE(PLAYER_ADULT_LIMB_R_HAND, PLAYER_WOLF_LIMB_R_PAD)) {
         Actor* heldActor = this->heldActor;
 
         if (this->rightHandType == PLAYER_MODELTYPE_RH_FF) {
@@ -1634,9 +1635,10 @@ void Player_PostLimbDrawGameplay(PlayState* play, s32 limbIndex, Gfx** dList, Ve
                     (this->exchangeItemId != EXCH_ITEM_NONE)) {
                     Math_Vec3f_Copy(&sGetItemRefPos, &this->leftHandPos);
                 } else {  // this sets reference position for getitem based on average of both hand positions
-                    sGetItemRefPos.x = (this->bodyPartsPos[PLAYER_ADULT_BODYPART_R_HAND].x + this->leftHandPos.x) * 0.5f;
-                    sGetItemRefPos.y = (this->bodyPartsPos[PLAYER_ADULT_BODYPART_R_HAND].y + this->leftHandPos.y) * 0.5f;
-                    sGetItemRefPos.z = (this->bodyPartsPos[PLAYER_ADULT_BODYPART_R_HAND].z + this->leftHandPos.z) * 0.5f;
+                    s32 bodyPartRHandIndex = LINK_AGE_VALUE(PLAYER_ADULT_BODYPART_R_HAND, PLAYER_WOLF_BODYPART_R_PAD);
+                    sGetItemRefPos.x = (this->bodyPartsPos[bodyPartRHandIndex].x + this->leftHandPos.x) * 0.5f;
+                    sGetItemRefPos.y = (this->bodyPartsPos[bodyPartRHandIndex].y + this->leftHandPos.y) * 0.5f;
+                    sGetItemRefPos.z = (this->bodyPartsPos[bodyPartRHandIndex].z + this->leftHandPos.z) * 0.5f;
                 }
 
                 if (this->unk_862 == 0) {
@@ -1645,25 +1647,27 @@ void Player_PostLimbDrawGameplay(PlayState* play, s32 limbIndex, Gfx** dList, Ve
             }
         }
     } else if (this->actor.scale.y >= 0.0f) {
-        if (limbIndex == PLAYER_ADULT_LIMB_SHEATH) {
+        // TODO: Decide which limb to attach stuff to (shield?) when sheathed.
+        if (LINK_IS_ADULT && limbIndex == PLAYER_ADULT_LIMB_SHEATH) {
             if ((this->rightHandType != PLAYER_MODELTYPE_RH_SHIELD) &&
                 (this->rightHandType != PLAYER_MODELTYPE_RH_FF)) {
                 if (Player_IsChildWithHylianShield(this)) {
                     Player_UpdateShieldCollider(play, this, &this->shieldQuad, sSheathLimbModelShieldQuadVertices);
                 }
 
-               // Matrix_TranslateRotateZYX(&sSheathLimbModelShieldOnBackPos, &sSheathLimbModelShieldOnBackZyxRot);
+                Matrix_TranslateRotateZYX(&sSheathLimbModelShieldOnBackPos, &sSheathLimbModelShieldOnBackZyxRot);
                 Matrix_Get(&this->shieldMf);
             }
-        } else if (limbIndex == PLAYER_ADULT_LIMB_HEAD) {
+        } else if (limbIndex == LINK_AGE_VALUE(PLAYER_ADULT_LIMB_HEAD, PLAYER_WOLF_LIMB_NECK)) {
             Matrix_MultVec3f(&sPlayerFocusHeadLimbModelPos, &this->actor.focus.pos);
         } else {
             Vec3f* footPos = &sLeftRightFootLimbModelFootPos[((void)0, gSaveContext.save.linkAge)];
 
             // The same model position is used for both feet,
             // but the resulting world position will be different for each limb.
-            Actor_SetFeetPos(&this->actor, limbIndex, (LINK_IS_ADULT ? PLAYER_ADULT_LIMB_L_FOOT : PLAYER_WOLF_LIMB_L_FOOT), 
-            footPos, (LINK_IS_ADULT ? PLAYER_ADULT_LIMB_R_FOOT : PLAYER_WOLF_LIMB_R_FOOT), footPos);
+            s32 limbLFootIndex = LINK_AGE_VALUE(PLAYER_ADULT_LIMB_L_FOOT, PLAYER_WOLF_LIMB_L_PAW);
+            s32 limbRFootIndex = LINK_AGE_VALUE(PLAYER_ADULT_LIMB_R_FOOT, PLAYER_WOLF_LIMB_R_PAW);
+            Actor_SetFeetPos(&this->actor, limbIndex, limbLFootIndex, footPos, limbRFootIndex, footPos);
         }
     }
 }
@@ -1709,6 +1713,7 @@ s32 Player_OverrideLimbDrawPause(PlayState* play, s32 limbIndex, Gfx** dList, Ve
     s32 dListOffset = 0;
     Gfx** dLists;
 
+    // TODO: Fix for wolf link
     if (!LINK_IS_ADULT) {
         return false;
     }
@@ -1718,24 +1723,25 @@ s32 Player_OverrideLimbDrawPause(PlayState* play, s32 limbIndex, Gfx** dList, Ve
         modelGroup = PLAYER_MODELGROUP_CHILD_HYLIAN_SHIELD;
     }
 
-    if (limbIndex == PLAYER_ADULT_LIMB_L_HAND) {
+    if (limbIndex == LINK_AGE_VALUE(PLAYER_ADULT_LIMB_L_HAND, PLAYER_WOLF_LIMB_L_PAD)) {
         type = gPlayerModelTypes[modelGroup][PLAYER_MODELGROUPENTRY_LEFT_HAND];
         sLeftHandType = type;
         if ((type == PLAYER_MODELTYPE_LH_BGS) && (gSaveContext.save.info.playerData.swordHealth <= 0.0f)) {
             dListOffset = 4;
         }
-    } else if (limbIndex == PLAYER_ADULT_LIMB_R_HAND) {
+    } else if (limbIndex == LINK_AGE_VALUE(PLAYER_ADULT_LIMB_R_HAND, PLAYER_WOLF_LIMB_R_PAD)) {
         type = gPlayerModelTypes[modelGroup][PLAYER_MODELGROUPENTRY_RIGHT_HAND];
         sRightHandType = type;
         if (type == PLAYER_MODELTYPE_RH_SHIELD) {
             dListOffset = playerSwordAndShield[1] * 4;
         }
-    } else if (limbIndex == PLAYER_ADULT_LIMB_SHEATH) {
+    } else if (LINK_IS_ADULT && limbIndex == PLAYER_ADULT_LIMB_SHEATH) {
+        // TODO: Decide which limb to attach stuff to (shield + sword?) when sheathed.
         type = gPlayerModelTypes[modelGroup][PLAYER_MODELGROUPENTRY_SHEATH];
         if ((type == PLAYER_MODELTYPE_SHEATH_18) || (type == PLAYER_MODELTYPE_SHEATH_19)) {
             dListOffset = playerSwordAndShield[1] * 4;
         }
-    } else if (limbIndex == PLAYER_ADULT_LIMB_WAIST) {
+    } else if (limbIndex == LINK_AGE_VALUE(PLAYER_ADULT_LIMB_WAIST, PLAYER_WOLF_LIMB_WAIST)) {
         type = gPlayerModelTypes[modelGroup][PLAYER_MODELGROUPENTRY_WAIST];
     } else {
         return false;

--- a/src/code/z_player_lib.c
+++ b/src/code/z_player_lib.c
@@ -8,7 +8,7 @@ typedef struct {
     /* 0x04 */ Vec3f pos;
 } BowSlingshotStringData; // size = 0x10
 
-FlexSkeletonHeader* gPlayerSkelHeaders[] = { &gLinkAdultSkel, &gLinkWolfSkel };
+FlexSkeletonHeader* gPlayerSkelHeaders[] = { &gLinkAdultSkel, &gLinkChildSkel };
 
 s16 sBootData[PLAYER_BOOTS_MAX][17] = {
     { 200, 1000, 300, 700, 550, 270, 600, 350, 800, 600, -100, 600, 590, 750, 125, 200, 130 }, // Kokiri Boots Adult (600)

--- a/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.c
+++ b/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.c
@@ -1477,7 +1477,7 @@ void BossFd_UpdateEffects(BossFd* this, PlayState* play) {
                     this->timers[3] = 50;
                     func_8002F6D4(play, NULL, 5.0f, effect->kbAngle, 0.0f, 0x30);
                     if (!player->isBurning) {
-                        for (i2 = 0; i2 < (LINK_IS_ADULT ? PLAYER_ADULT_BODYPART_MAX : PLAYER_WOLF_BODYPART_MAX); i2++) {
+                        for (i2 = 0; i2 < PLAYER_BODYPART_MAX; i2++) {
                             player->flameTimers[i2] = Rand_S16Offset(0, 200);
                         }
                         player->isBurning = true;

--- a/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
+++ b/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
@@ -3353,7 +3353,7 @@ void BossGanon_DrawShock(BossGanon* this, PlayState* play) {
         if (this->unk_2E8 != 0) {
             Player* player = GET_PLAYER(play);
 
-            for (i = 0; i < (LINK_IS_ADULT ? PLAYER_ADULT_BODYPART_MAX : PLAYER_WOLF_BODYPART_MAX); i++) {
+            for (i = 0; i < PLAYER_BODYPART_MAX; i++) {
                 Matrix_Translate(player->bodyPartsPos[i].x, player->bodyPartsPos[i].y, player->bodyPartsPos[i].z,
                                  MTXMODE_NEW);
                 Matrix_ReplaceRotation(&play->billboardMtxF);
@@ -3533,8 +3533,9 @@ void BossGanon_DrawTriforce(BossGanon* this, PlayState* play) {
 
         if (this->triforceType == GDF_TRIFORCE_PLAYER) {
             Player* player = GET_PLAYER(play);
+            s16 bodyPartLHandIndex = LINK_AGE_VALUE(PLAYER_ADULT_BODYPART_L_HAND, PLAYER_WOLF_BODYPART_L_PAD);
 
-            this->triforcePos = player->bodyPartsPos[(LINK_IS_ADULT ? PLAYER_ADULT_BODYPART_L_HAND : PLAYER_WOLF_BODYPART_L_PAD)];
+            this->triforcePos = player->bodyPartsPos[bodyPartLHandIndex];
 
             this->triforcePos.x += -0.6f;
             this->triforcePos.y += 3.0f;
@@ -4688,7 +4689,7 @@ void BossGanon_UpdateEffects(PlayState* play) {
                     eff->pos.y = sGanondorf->unk_2EC[bodyPart].y + Rand_CenteredFloat(20.0f);
                     eff->pos.z = sGanondorf->unk_2EC[bodyPart].z + Rand_CenteredFloat(20.0f);
                 } else {
-                    bodyPart = (s16)Rand_ZeroFloat((LINK_IS_ADULT ? PLAYER_ADULT_BODYPART_MAX : PLAYER_WOLF_BODYPART_MAX) - 0.1f);
+                    bodyPart = (s16)Rand_ZeroFloat(PLAYER_BODYPART_MAX - 0.1f);
 
                     eff->pos.x = player->bodyPartsPos[bodyPart].x + Rand_CenteredFloat(10.0f);
                     eff->pos.y = player->bodyPartsPos[bodyPart].y + Rand_CenteredFloat(15.0f);

--- a/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
+++ b/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
@@ -1867,7 +1867,7 @@ void func_80902348(BossGanon2* this, PlayState* play) {
         temp_f12 = -200.0f - player->actor.world.pos.z;
 
         if (sqrtf(SQ(temp_f2) + SQ(temp_f12)) > 784.0f) {
-            for (j = 0; j < (LINK_IS_ADULT ? PLAYER_ADULT_BODYPART_MAX : PLAYER_WOLF_BODYPART_MAX); j++) {
+            for (j = 0; j < PLAYER_BODYPART_MAX; j++) {
                 player->flameTimers[j] = Rand_S16Offset(0, 200);
             }
 

--- a/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
+++ b/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
@@ -389,8 +389,9 @@ void BossTw_AddShieldDeflectEffect(PlayState* play, f32 arg1, s16 arg2) {
     s16 j;
     BossTwEffect* eff;
     Player* player = GET_PLAYER(play);
+    s16 bodyPartRHandIndex = LINK_AGE_VALUE(PLAYER_ADULT_BODYPART_R_HAND, PLAYER_WOLF_BODYPART_R_PAD);
 
-    sShieldHitPos = player->bodyPartsPos[PLAYER_ADULT_BODYPART_R_HAND];
+    sShieldHitPos = player->bodyPartsPos[bodyPartRHandIndex];
     sShieldHitYaw = player->actor.shape.rot.y;
 
     for (i = 0; i < 8; i++) {
@@ -419,8 +420,9 @@ void BossTw_AddShieldHitEffect(PlayState* play, f32 arg1, s16 arg2) {
     s16 j;
     BossTwEffect* eff;
     Player* player = GET_PLAYER(play);
+    s16 bodyPartRHandIndex = LINK_AGE_VALUE(PLAYER_ADULT_BODYPART_R_HAND, PLAYER_WOLF_BODYPART_R_PAD);
 
-    sShieldHitPos = player->bodyPartsPos[PLAYER_ADULT_BODYPART_R_HAND];
+    sShieldHitPos = player->bodyPartsPos[bodyPartRHandIndex];
     sShieldHitYaw = player->actor.shape.rot.y;
 
     for (i = 0; i < 8; i++) {
@@ -812,7 +814,7 @@ s32 BossTw_BeamHitPlayerCheck(BossTw* this, PlayState* play) {
                     sFreezeState = 1;
                 }
             } else if (!player->isBurning) {
-                for (i = 0; i < (LINK_IS_ADULT ? PLAYER_ADULT_BODYPART_MAX : PLAYER_WOLF_BODYPART_MAX); i++) {
+                for (i = 0; i < PLAYER_BODYPART_MAX; i++) {
                     player->flameTimers[i] = Rand_S16Offset(0, 200);
                 }
 
@@ -971,6 +973,7 @@ void BossTw_ShootBeam(BossTw* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
     BossTw* otherTw = (BossTw*)this->actor.parent;
     Input* input = &play->state.input[0];
+    s16 bodyPartRHandIndex = LINK_AGE_VALUE(PLAYER_ADULT_BODYPART_R_HAND, PLAYER_WOLF_BODYPART_R_PAD);
 
     Math_ApproachF(&this->actor.world.pos.y, 400.0f, 0.05f, this->actor.speed);
     Math_ApproachF(&this->actor.speed, 5.0f, 1.0f, 0.25f);
@@ -982,9 +985,9 @@ void BossTw_ShootBeam(BossTw* this, PlayState* play) {
         if ((player->stateFlags1 & PLAYER_STATE1_22) &&
             ((s16)((player->actor.shape.rot.y - this->actor.shape.rot.y) + 0x8000) < 0x2000) &&
             ((s16)((player->actor.shape.rot.y - this->actor.shape.rot.y) + 0x8000) > -0x2000)) {
-            Math_ApproachF(&this->targetPos.x, player->bodyPartsPos[PLAYER_ADULT_BODYPART_R_HAND].x, 1.0f, 400.0f);
-            Math_ApproachF(&this->targetPos.y, player->bodyPartsPos[PLAYER_ADULT_BODYPART_R_HAND].y, 1.0f, 400.0f);
-            Math_ApproachF(&this->targetPos.z, player->bodyPartsPos[PLAYER_ADULT_BODYPART_R_HAND].z, 1.0f, 400.0f);
+            Math_ApproachF(&this->targetPos.x, player->bodyPartsPos[bodyPartRHandIndex].x, 1.0f, 400.0f);
+            Math_ApproachF(&this->targetPos.y, player->bodyPartsPos[bodyPartRHandIndex].y, 1.0f, 400.0f);
+            Math_ApproachF(&this->targetPos.z, player->bodyPartsPos[bodyPartRHandIndex].z, 1.0f, 400.0f);
         } else {
             Math_ApproachF(&this->targetPos.x, player->actor.world.pos.x, 1.0f, 400.0f);
             Math_ApproachF(&this->targetPos.y, player->actor.world.pos.y + 30.0f, 1.0f, 400.0f);
@@ -1102,7 +1105,7 @@ void BossTw_ShootBeam(BossTw* this, PlayState* play) {
                             velocity.x = Rand_CenteredFloat(15.0f);
                             velocity.y = Rand_CenteredFloat(15.0f);
                             velocity.z = Rand_CenteredFloat(15.0f);
-                            pos = player->bodyPartsPos[PLAYER_ADULT_BODYPART_R_HAND];
+                            pos = player->bodyPartsPos[bodyPartRHandIndex];
                             BossTw_AddDotEffect(play, &pos, &velocity, &accel, (s16)Rand_ZeroFloat(2.0f) + 5,
                                                 this->actor.params, 150);
                         }
@@ -1147,11 +1150,11 @@ void BossTw_ShootBeam(BossTw* this, PlayState* play) {
 
                     this->beamDist = sqrtf(SQ(xDiff) + SQ(yDiff) + SQ(zDiff));
                     Math_ApproachF(&this->beamReflectionDist, 2000.0f, 1.0f, 40.0f);
-                    Math_ApproachF(&this->targetPos.x, player->bodyPartsPos[PLAYER_ADULT_BODYPART_R_HAND].x, 1.0f, 400.0f);
-                    Math_ApproachF(&this->targetPos.y, player->bodyPartsPos[PLAYER_ADULT_BODYPART_R_HAND].y, 1.0f, 400.0f);
-                    Math_ApproachF(&this->targetPos.z, player->bodyPartsPos[PLAYER_ADULT_BODYPART_R_HAND].z, 1.0f, 400.0f);
+                    Math_ApproachF(&this->targetPos.x, player->bodyPartsPos[bodyPartRHandIndex].x, 1.0f, 400.0f);
+                    Math_ApproachF(&this->targetPos.y, player->bodyPartsPos[bodyPartRHandIndex].y, 1.0f, 400.0f);
+                    Math_ApproachF(&this->targetPos.z, player->bodyPartsPos[bodyPartRHandIndex].z, 1.0f, 400.0f);
                     if ((this->work[CS_TIMER_1] % 4) == 0) {
-                        BossTw_AddRingEffect(play, &player->bodyPartsPos[PLAYER_ADULT_BODYPART_R_HAND], 0.5f, 3.0f, 0xFF,
+                        BossTw_AddRingEffect(play, &player->bodyPartsPos[bodyPartRHandIndex], 0.5f, 3.0f, 0xFF,
                                              this->actor.params, 1, BOSS_TW_EFFECT_COUNT);
                     }
                 } else {
@@ -3912,6 +3915,7 @@ void BossTw_BlastFire(BossTw* this, PlayState* play) {
     f32 distXZ;
     Player* player = GET_PLAYER(play);
     Player* player2 = player;
+    s16 bodyPartRHandIndex = LINK_AGE_VALUE(PLAYER_ADULT_BODYPART_R_HAND, PLAYER_WOLF_BODYPART_R_PAD);
 
     switch (this->actor.params) {
         case TW_FIRE_BLAST:
@@ -3947,7 +3951,7 @@ void BossTw_BlastFire(BossTw* this, PlayState* play) {
                         Vec3s blastDir;
                         s16 alpha;
 
-                        this->actor.world.pos = player2->bodyPartsPos[PLAYER_ADULT_BODYPART_R_HAND];
+                        this->actor.world.pos = player2->bodyPartsPos[bodyPartRHandIndex];
                         this->actor.world.pos.y = -2000.0f;
                         Matrix_MtxFToYXZRotS(&player2->shieldMf, &blastDir, 0);
                         blastDir.x = -blastDir.x;
@@ -3973,7 +3977,7 @@ void BossTw_BlastFire(BossTw* this, PlayState* play) {
                             alpha = this->timers[0] * 10;
                             alpha = CLAMP_MAX(alpha, 255);
 
-                            BossTw_AddShieldBlastEffect(play, &player2->bodyPartsPos[PLAYER_ADULT_BODYPART_R_HAND], &velocity,
+                            BossTw_AddShieldBlastEffect(play, &player2->bodyPartsPos[bodyPartRHandIndex], &velocity,
                                                         &sZeroVector, 10.0f, 80.0f, alpha, 1);
                         }
 
@@ -4102,6 +4106,7 @@ void BossTw_BlastIce(BossTw* this, PlayState* play) {
     f32 xzDist;
     Player* player = GET_PLAYER(play);
     Player* player2 = player;
+    s16 bodyPartRHandIndex = LINK_AGE_VALUE(PLAYER_ADULT_BODYPART_R_HAND, PLAYER_WOLF_BODYPART_R_PAD);
 
     switch (this->actor.params) {
         case TW_ICE_BLAST:
@@ -4136,7 +4141,7 @@ void BossTw_BlastIce(BossTw* this, PlayState* play) {
                         Vec3s reflDir;
                         s16 alpha;
 
-                        this->actor.world.pos = player2->bodyPartsPos[PLAYER_ADULT_BODYPART_R_HAND];
+                        this->actor.world.pos = player2->bodyPartsPos[bodyPartRHandIndex];
                         this->actor.world.pos.y = -2000.0f;
                         Matrix_MtxFToYXZRotS(&player2->shieldMf, &reflDir, 0);
                         reflDir.x = -reflDir.x;
@@ -4162,7 +4167,7 @@ void BossTw_BlastIce(BossTw* this, PlayState* play) {
                             alpha = this->timers[0] * 10;
                             alpha = CLAMP_MAX(alpha, 255);
 
-                            BossTw_AddShieldBlastEffect(play, &player2->bodyPartsPos[PLAYER_ADULT_BODYPART_R_HAND], &velocity,
+                            BossTw_AddShieldBlastEffect(play, &player2->bodyPartsPos[bodyPartRHandIndex], &velocity,
                                                         &sZeroVector, 10.0f, 80.0f, alpha, 0);
                         }
 
@@ -4834,7 +4839,7 @@ void BossTw_UpdateEffects(PlayState* play) {
                     }
 
                     if ((eff->workf[EFF_DIST] > 0.4f) && ((eff->frame & 7) == 0)) {
-                        spA6 = Rand_ZeroFloat((LINK_IS_ADULT ? PLAYER_ADULT_BODYPART_MAX : PLAYER_WOLF_BODYPART_MAX) - 0.1f);
+                        spA6 = Rand_ZeroFloat(PLAYER_BODYPART_MAX - 0.1f);
 
                         if (eff->target == NULL) {
                             spC0.x = player->bodyPartsPos[spA6].x + Rand_CenteredFloat(5.0f);

--- a/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
+++ b/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
@@ -3318,7 +3318,7 @@ void BossVa_UpdateEffects(PlayState* play) {
                 effect->pos.y = effect->offset.y + refActor->actor.world.pos.y;
                 effect->pos.z = effect->offset.z + refActor->actor.world.pos.z;
             } else {
-                spB6 = Rand_ZeroFloat((LINK_IS_ADULT ? PLAYER_ADULT_BODYPART_MAX : PLAYER_WOLF_BODYPART_MAX) - 0.1f);
+                spB6 = Rand_ZeroFloat(PLAYER_BODYPART_MAX - 0.1f);
                 effect->pos.x = player->bodyPartsPos[spB6].x + Rand_CenteredFloat(10.0f);
                 effect->pos.y = player->bodyPartsPos[spB6].y + Rand_CenteredFloat(15.0f);
                 effect->pos.z = player->bodyPartsPos[spB6].z + Rand_CenteredFloat(10.0f);
@@ -3746,7 +3746,7 @@ void BossVa_SpawnSpark(PlayState* play, BossVaEffect* effect, BossVa* this, Vec3
 
                 case SPARK_LINK:
                     effect->type = VA_SMALL_SPARK;
-                    index = Rand_ZeroFloat((LINK_IS_ADULT ? PLAYER_ADULT_BODYPART_MAX : PLAYER_WOLF_BODYPART_MAX) - 0.1f);
+                    index = Rand_ZeroFloat(PLAYER_BODYPART_MAX - 0.1f);
                     effect->pos.x = player->bodyPartsPos[index].x + Rand_CenteredFloat(10.0f);
                     effect->pos.y = player->bodyPartsPos[index].y + Rand_CenteredFloat(15.0f);
                     effect->pos.z = player->bodyPartsPos[index].z + Rand_CenteredFloat(10.0f);

--- a/src/overlays/actors/ovl_Demo_Du/z_demo_du.c
+++ b/src/overlays/actors/ovl_Demo_Du/z_demo_du.c
@@ -395,7 +395,8 @@ void DemoDu_CsGoronsRuby_SpawnDustWhenHittingLink(DemoDu* this, PlayState* play)
         s32 pad[2];
         s32 i;
         Player* player = GET_PLAYER(play);
-        Vec3f* pos = &player->bodyPartsPos[PLAYER_ADULT_BODYPART_L_FOREARM];
+        s16 bodyPartLForearmIndex = LINK_AGE_VALUE(PLAYER_ADULT_BODYPART_L_FOREARM, PLAYER_WOLF_BODYPART_L_FOREARM);
+        Vec3f* pos = &player->bodyPartsPos[bodyPartLForearmIndex];
         Vec3f velocity = { 0.0f, 0.0f, 0.0f };
         Vec3f accel = { 0.0f, 0.3f, 0.0f };
         s32 pad2;

--- a/src/overlays/actors/ovl_En_Elf/z_en_elf.c
+++ b/src/overlays/actors/ovl_En_Elf/z_en_elf.c
@@ -603,6 +603,7 @@ void func_80A0329C(EnElf* this, PlayState* play) {
     s32 pad;
     Player* player = GET_PLAYER(play);
     f32 heightDiff;
+    s16 bodyPartWaistIndex = LINK_AGE_VALUE(PLAYER_ADULT_BODYPART_WAIST, PLAYER_WOLF_BODYPART_WAIST);
 
     SkelAnime_Update(&this->skelAnime);
 
@@ -612,7 +613,7 @@ void func_80A0329C(EnElf* this, PlayState* play) {
     }
 
     func_80A0232C(this, play);
-    this->unk_28C.y = player->bodyPartsPos[PLAYER_ADULT_BODYPART_WAIST].y;
+    this->unk_28C.y = player->bodyPartsPos[bodyPartWaistIndex].y;
     func_80A02F2C(this, &this->unk_28C);
     func_80A03018(this, play);
 
@@ -734,6 +735,7 @@ void func_80A03610(EnElf* this, PlayState* play) {
 
 void func_80A03814(EnElf* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
+    s16 bodyPartWaistIndex = LINK_AGE_VALUE(PLAYER_ADULT_BODYPART_WAIST, PLAYER_WOLF_BODYPART_WAIST);
 
     SkelAnime_Update(&this->skelAnime);
 
@@ -761,7 +763,7 @@ void func_80A03814(EnElf* this, PlayState* play) {
     this->unk_28C.x = Math_CosS(this->unk_2AC) * this->unk_2B8;
     this->unk_28C.z = Math_SinS(this->unk_2AC) * -this->unk_2B8;
     this->unk_2AC += this->unk_2B0;
-    func_80A02E30(this, &player->bodyPartsPos[PLAYER_ADULT_BODYPART_WAIST]);
+    func_80A02E30(this, &player->bodyPartsPos[bodyPartWaistIndex]);
     this->unk_2BC = Math_Atan2S(this->actor.velocity.z, this->actor.velocity.x);
     EnElf_SpawnSparkles(this, play, 32);
     Actor_PlaySfx(&this->actor, NA_SE_EV_FIATY_HEAL - SFX_FLAG);
@@ -769,6 +771,7 @@ void func_80A03814(EnElf* this, PlayState* play) {
 
 void func_80A03990(EnElf* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
+    s16 bodyPartWaistIndex = LINK_AGE_VALUE(PLAYER_ADULT_BODYPART_WAIST, PLAYER_WOLF_BODYPART_WAIST);
 
     SkelAnime_Update(&this->skelAnime);
 
@@ -785,7 +788,7 @@ void func_80A03990(EnElf* this, PlayState* play) {
         this->unk_2B8 = 1.0f;
     }
 
-    func_80A02E30(this, &player->bodyPartsPos[PLAYER_ADULT_BODYPART_WAIST]);
+    func_80A02E30(this, &player->bodyPartsPos[bodyPartWaistIndex]);
     Actor_SetScale(&this->actor, (1.0f - (SQ(this->unk_2B4) * SQ(1.0f / 9.0f))) * 0.008f);
     this->unk_2BC = Math_Atan2S(this->actor.velocity.z, this->actor.velocity.x);
     EnElf_SpawnSparkles(this, play, 32);
@@ -841,6 +844,7 @@ void func_80A03CF8(EnElf* this, PlayState* play) {
     Actor* arrowPointedActor;
     f32 xScale;
     f32 distFromPlayerHat;
+    s16 bodyPartHatIndex = LINK_AGE_VALUE(PLAYER_ADULT_BODYPART_HAT, PLAYER_WOLF_BODYPART_HEAD);
 
     func_80A0461C(this, play);
     func_80A03AB0(this, play);
@@ -885,12 +889,12 @@ void func_80A03CF8(EnElf* this, PlayState* play) {
             }
         }
     } else {
-        distFromPlayerHat = Math_Vec3f_DistXYZ(&player->bodyPartsPos[(LINK_IS_ADULT ? PLAYER_ADULT_BODYPART_HAT : PLAYER_WOLF_BODYPART_HEAD)], &this->actor.world.pos);
+        distFromPlayerHat = Math_Vec3f_DistXYZ(&player->bodyPartsPos[bodyPartHatIndex], &this->actor.world.pos);
 
         switch (this->unk_2A8) {
             case 7:
-                func_80A02C98(this, &player->bodyPartsPos[(LINK_IS_ADULT ? PLAYER_ADULT_BODYPART_HAT : PLAYER_WOLF_BODYPART_HEAD)], 1.0f - this->unk_2AE * (1.0f / 30.0f));
-                xScale = Math_Vec3f_DistXYZ(&player->bodyPartsPos[(LINK_IS_ADULT ? PLAYER_ADULT_BODYPART_HAT : PLAYER_WOLF_BODYPART_HEAD)], &this->actor.world.pos);
+                func_80A02C98(this, &player->bodyPartsPos[bodyPartHatIndex], 1.0f - this->unk_2AE * (1.0f / 30.0f));
+                xScale = Math_Vec3f_DistXYZ(&player->bodyPartsPos[bodyPartHatIndex], &this->actor.world.pos);
 
                 if (distFromPlayerHat < 7.0f) {
                     this->unk_2C0 = 0;
@@ -905,12 +909,12 @@ void func_80A03CF8(EnElf* this, PlayState* play) {
                 EnElf_SpawnSparkles(this, play, 16);
                 break;
             case 8:
-                func_80A02C98(this, &player->bodyPartsPos[(LINK_IS_ADULT ? PLAYER_ADULT_BODYPART_HAT : PLAYER_WOLF_BODYPART_HEAD)], 0.2f);
-                this->actor.world.pos = player->bodyPartsPos[(LINK_IS_ADULT ? PLAYER_ADULT_BODYPART_HAT : PLAYER_WOLF_BODYPART_HEAD)];
+                func_80A02C98(this, &player->bodyPartsPos[bodyPartHatIndex], 0.2f);
+                this->actor.world.pos = player->bodyPartsPos[bodyPartHatIndex];
                 func_80A029A8(this, 1);
                 break;
             case 11:
-                nextPos = player->bodyPartsPos[(LINK_IS_ADULT ? PLAYER_ADULT_BODYPART_HAT : PLAYER_WOLF_BODYPART_HEAD)];
+                nextPos = player->bodyPartsPos[bodyPartHatIndex];
                 nextPos.y += 1500.0f * this->actor.scale.y;
                 func_80A02E30(this, &nextPos);
                 EnElf_SpawnSparkles(this, play, 16);
@@ -1058,6 +1062,7 @@ void func_80A0461C(EnElf* this, PlayState* play) {
     s32 temp;
     Actor* arrowPointedActor;
     Player* player = GET_PLAYER(play);
+    s16 bodyPartHatIndex = LINK_AGE_VALUE(PLAYER_ADULT_BODYPART_HAT, PLAYER_WOLF_BODYPART_HEAD);
 
     if (play->csCtx.state != CS_STATE_IDLE) {
         if (play->csCtx.actorCues[8] != NULL) {
@@ -1176,8 +1181,8 @@ void func_80A0461C(EnElf* this, PlayState* play) {
         func_80A01C38(this, temp);
 
         if (temp == 11) {
-            this->unk_2B8 = Math_Vec3f_DistXZ(&player->bodyPartsPos[(LINK_IS_ADULT ? PLAYER_ADULT_BODYPART_HAT : PLAYER_WOLF_BODYPART_HEAD)], &this->actor.world.pos);
-            this->unk_2AC = Math_Vec3f_Yaw(&this->actor.world.pos, &player->bodyPartsPos[(LINK_IS_ADULT ? PLAYER_ADULT_BODYPART_HAT : PLAYER_WOLF_BODYPART_HEAD)]);
+            this->unk_2B8 = Math_Vec3f_DistXZ(&player->bodyPartsPos[bodyPartHatIndex], &this->actor.world.pos);
+            this->unk_2AC = Math_Vec3f_Yaw(&this->actor.world.pos, &player->bodyPartsPos[bodyPartHatIndex]);
         }
     }
 }
@@ -1220,16 +1225,17 @@ void func_80A04DE4(EnElf* this, PlayState* play) {
     Vec3f headCopy;
     Player* player = GET_PLAYER(play);
     Vec3f naviRefPos;
+    s16 bodyPartHeadIndex = LINK_AGE_VALUE(PLAYER_ADULT_BODYPART_HEAD, PLAYER_WOLF_BODYPART_NECK);
 
     if (this->fairyFlags & 0x10) {
         naviRefPos = play->actorCtx.targetCtx.naviRefPos;
 
         if ((player->unk_664 == NULL) || (&player->actor == player->unk_664) || (&this->actor == player->unk_664)) {
             naviRefPos.x =
-                player->bodyPartsPos[(LINK_IS_ADULT ? PLAYER_ADULT_BODYPART_HEAD : PLAYER_WOLF_BODYPART_HEAD)].x + (Math_SinS(player->actor.shape.rot.y) * 20.0f);
-            naviRefPos.y = player->bodyPartsPos[(LINK_IS_ADULT ? PLAYER_ADULT_BODYPART_HEAD : PLAYER_WOLF_BODYPART_HEAD)].y + 5.0f;
+                player->bodyPartsPos[bodyPartHeadIndex].x + (Math_SinS(player->actor.shape.rot.y) * 20.0f);
+            naviRefPos.y = player->bodyPartsPos[bodyPartHeadIndex].y + 5.0f;
             naviRefPos.z =
-                player->bodyPartsPos[(LINK_IS_ADULT ? PLAYER_ADULT_BODYPART_HEAD : PLAYER_WOLF_BODYPART_HEAD)].z + (Math_CosS(player->actor.shape.rot.y) * 20.0f);
+                player->bodyPartsPos[bodyPartHeadIndex].z + (Math_CosS(player->actor.shape.rot.y) * 20.0f);
         }
 
         this->actor.focus.pos = naviRefPos;

--- a/src/overlays/actors/ovl_En_Ge2/z_en_ge2.c
+++ b/src/overlays/actors/ovl_En_Ge2/z_en_ge2.c
@@ -200,6 +200,7 @@ s32 Ge2_DetectPlayerInUpdate(PlayState* play, EnGe2* this, Vec3f* pos, s16 yRot,
     Vec3f posResult;
     CollisionPoly* outPoly;
     f32 visionScale;
+    s16 bodyPartHeadIndex = LINK_AGE_VALUE(PLAYER_ADULT_BODYPART_HEAD, PLAYER_WOLF_BODYPART_NECK);
 
     visionScale = (!IS_DAY ? 0.75f : 1.5f);
 
@@ -215,8 +216,7 @@ s32 Ge2_DetectPlayerInUpdate(PlayState* play, EnGe2* this, Vec3f* pos, s16 yRot,
         return 0;
     }
 
-    if (BgCheck_AnyLineTest1(&play->colCtx, pos, &player->bodyPartsPos[(LINK_IS_ADULT ? PLAYER_ADULT_BODYPART_HEAD : PLAYER_WOLF_BODYPART_HEAD)], &posResult, &outPoly,
-                             0)) {
+    if (BgCheck_AnyLineTest1(&play->colCtx, pos, &player->bodyPartsPos[bodyPartHeadIndex], &posResult, &outPoly, 0)) {
         return 0;
     }
     return 1;

--- a/src/overlays/actors/ovl_En_M_Thunder/z_en_m_thunder.c
+++ b/src/overlays/actors/ovl_En_M_Thunder/z_en_m_thunder.c
@@ -63,6 +63,7 @@ void EnMThunder_Init(Actor* thisx, PlayState* play2) {
     PlayState* play = play2;
     EnMThunder* this = (EnMThunder*)thisx;
     Player* player = GET_PLAYER(play);
+    s16 bodyPartWaistIndex = LINK_AGE_VALUE(PLAYER_ADULT_BODYPART_WAIST, PLAYER_WOLF_BODYPART_WAIST);
 
     Collider_InitCylinder(play, &this->collider);
     Collider_SetCylinder(play, &this->collider, &this->actor, &D_80AA0420);
@@ -75,7 +76,7 @@ void EnMThunder_Init(Actor* thisx, PlayState* play2) {
     this->collider.dim.yShift = -20;
     this->unk_1C4 = 8;
     this->unk_1B4 = 0.0f;
-    this->actor.world.pos = player->bodyPartsPos[PLAYER_ADULT_BODYPART_WAIST];
+    this->actor.world.pos = player->bodyPartsPos[bodyPartWaistIndex];
     this->unk_1AC = 0.0f;
     this->unk_1BC = 0.0f;
     this->actor.shape.rot.y = player->actor.shape.rot.y + 0x8000;
@@ -150,9 +151,10 @@ void func_80A9F350(EnMThunder* this, PlayState* play) {
 void func_80A9F408(EnMThunder* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
     Actor* child = this->actor.child;
+    s16 bodyPartWaistIndex = LINK_AGE_VALUE(PLAYER_ADULT_BODYPART_WAIST, PLAYER_WOLF_BODYPART_WAIST);
 
     this->unk_1B8 = player->unk_858;
-    this->actor.world.pos = player->bodyPartsPos[PLAYER_ADULT_BODYPART_WAIST];
+    this->actor.world.pos = player->bodyPartsPos[bodyPartWaistIndex];
     this->actor.shape.rot.y = player->actor.shape.rot.y + 0x8000;
 
     if (this->unk_1CA == 0) {
@@ -271,6 +273,7 @@ void func_80A9F938(EnMThunder* this, PlayState* play) {
 
 void func_80A9F9B4(EnMThunder* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
+    s16 bodyPartWaistIndex = LINK_AGE_VALUE(PLAYER_ADULT_BODYPART_WAIST, PLAYER_WOLF_BODYPART_WAIST);
 
     if (Math_StepToF(&this->unk_1AC, 0.0f, 1 / 16.0f)) {
         Actor_Kill(&this->actor);
@@ -283,8 +286,8 @@ void func_80A9F9B4(EnMThunder* this, PlayState* play) {
     }
 
     if (this->unk_1C4 > 0) {
-        this->actor.world.pos.x = player->bodyPartsPos[PLAYER_ADULT_BODYPART_WAIST].x;
-        this->actor.world.pos.z = player->bodyPartsPos[PLAYER_ADULT_BODYPART_WAIST].z;
+        this->actor.world.pos.x = player->bodyPartsPos[bodyPartWaistIndex].x;
+        this->actor.world.pos.z = player->bodyPartsPos[bodyPartWaistIndex].z;
         this->unk_1C4--;
     }
 

--- a/src/overlays/actors/ovl_En_Sda/z_en_sda.c
+++ b/src/overlays/actors/ovl_En_Sda/z_en_sda.c
@@ -59,8 +59,10 @@ static u8 D_80AFA15C[] = {
     2, 2, 2, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0, 0, 3,
 };
 
-static s8 D_80AFA16C[PLAYER_ADULT_BODYPART_MAX] = {
+static s8 D_80AFA16C[PLAYER_BODYPART_ARR_COUNT] = {
     2, 9, 10, 11, 12, 13, 14, 0, 15, -1, 3, 4, 5, 6, 7, 8, -1, 1,
+    // TODO: Figure out valid values for the following body parts.
+    -1, -1, -1, -1, -1, -1, -1, -1,
 };
 
 static Vec3f D_80AFA180[] = {
@@ -266,7 +268,7 @@ void func_80AF95C4(EnSda* this, u8* shadowTexture, Player* player, PlayState* pl
         }
     }
     Matrix_RotateX((BREG(50) + 70) / 100.0f, MTXMODE_NEW);
-    for (i = 0; i < PLAYER_ADULT_BODYPART_MAX; i++) {
+    for (i = 0; i < PLAYER_BODYPART_MAX; i++) {
         if (D_80AFA16C[i] >= 0) {
             D_80AFA660[D_80AFA16C[i]] = player->bodyPartsPos[i];
         }

--- a/src/overlays/actors/ovl_Fishing/z_fishing.c
+++ b/src/overlays/actors/ovl_Fishing/z_fishing.c
@@ -2919,6 +2919,7 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
     f32 rumbleStrength;
     u16 attempts;
     u8 rumbleStrength8;
+    s16 bodyPartRHandIndex = LINK_AGE_VALUE(PLAYER_ADULT_BODYPART_R_HAND, PLAYER_WOLF_BODYPART_R_PAD);
 
     this->actor.uncullZoneForward = 700.0f;
     this->actor.uncullZoneScale = 50.0f;
@@ -3909,11 +3910,11 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
             multiVecSrc.y = -10.0f;
             multiVecSrc.z = 5.0f;
             Matrix_MultVec3f(&multiVecSrc, &targetPosOffset);
-            Math_ApproachF(&this->actor.world.pos.x, player->bodyPartsPos[PLAYER_ADULT_BODYPART_R_HAND].x + targetPosOffset.x,
+            Math_ApproachF(&this->actor.world.pos.x, player->bodyPartsPos[bodyPartRHandIndex].x + targetPosOffset.x,
                            1.0f, 6.0f);
-            Math_ApproachF(&this->actor.world.pos.y, player->bodyPartsPos[PLAYER_ADULT_BODYPART_R_HAND].y + targetPosOffset.y,
+            Math_ApproachF(&this->actor.world.pos.y, player->bodyPartsPos[bodyPartRHandIndex].y + targetPosOffset.y,
                            1.0f, 6.0f);
-            Math_ApproachF(&this->actor.world.pos.z, player->bodyPartsPos[PLAYER_ADULT_BODYPART_R_HAND].z + targetPosOffset.z,
+            Math_ApproachF(&this->actor.world.pos.z, player->bodyPartsPos[bodyPartRHandIndex].z + targetPosOffset.z,
                            1.0f, 6.0f);
 
             sRodLineSpooled = 188.0f;

--- a/src/overlays/actors/ovl_Magic_Dark/z_magic_dark.c
+++ b/src/overlays/actors/ovl_Magic_Dark/z_magic_dark.c
@@ -177,6 +177,7 @@ void MagicDark_OrbUpdate(Actor* thisx, PlayState* play) {
     MagicDark* this = (MagicDark*)thisx;
     s32 pad;
     Player* player = GET_PLAYER(play);
+    s16 bodyPartWaistIndex = LINK_AGE_VALUE(PLAYER_ADULT_BODYPART_WAIST, PLAYER_WOLF_BODYPART_WAIST);
 
     func_8002F974(&this->actor, NA_SE_PL_MAGIC_SOUL_BALL - SFX_FLAG);
     if (this->timer < 35) {
@@ -185,7 +186,7 @@ void MagicDark_OrbUpdate(Actor* thisx, PlayState* play) {
         Actor_SetScale(&this->actor, thisx->scale.x);
     } else if (this->timer < 55) {
         Actor_SetScale(&this->actor, thisx->scale.x * 0.9f);
-        Math_SmoothStepToF(&this->orbOffset.y, player->bodyPartsPos[PLAYER_ADULT_BODYPART_WAIST].y, 0.5f, 3.0f, 1.0f);
+        Math_SmoothStepToF(&this->orbOffset.y, player->bodyPartsPos[bodyPartWaistIndex].y, 0.5f, 3.0f, 1.0f);
         if (this->timer > 48) {
             MagicDark_DimLighting(play, (54 - this->timer) * 0.2f);
         }
@@ -205,6 +206,7 @@ void MagicDark_DiamondDraw(Actor* thisx, PlayState* play) {
     MagicDark* this = (MagicDark*)thisx;
     s32 pad;
     u16 gameplayFrames = play->gameplayFrames;
+    s16 bodyPartWaistIndex = LINK_AGE_VALUE(PLAYER_ADULT_BODYPART_WAIST, PLAYER_WOLF_BODYPART_WAIST);
 
     OPEN_DISPS(play->state.gfxCtx);
 
@@ -214,13 +216,13 @@ void MagicDark_DiamondDraw(Actor* thisx, PlayState* play) {
         Player* player = GET_PLAYER(play);
         f32 heightDiff;
 
-        this->actor.world.pos.x = player->bodyPartsPos[PLAYER_ADULT_BODYPART_WAIST].x;
-        this->actor.world.pos.z = player->bodyPartsPos[PLAYER_ADULT_BODYPART_WAIST].z;
-        heightDiff = player->bodyPartsPos[PLAYER_ADULT_BODYPART_WAIST].y - this->actor.world.pos.y;
+        this->actor.world.pos.x = player->bodyPartsPos[bodyPartWaistIndex].x;
+        this->actor.world.pos.z = player->bodyPartsPos[bodyPartWaistIndex].z;
+        heightDiff = player->bodyPartsPos[bodyPartWaistIndex].y - this->actor.world.pos.y;
         if (heightDiff < -2.0f) {
-            this->actor.world.pos.y = player->bodyPartsPos[PLAYER_ADULT_BODYPART_WAIST].y + 2.0f;
+            this->actor.world.pos.y = player->bodyPartsPos[bodyPartWaistIndex].y + 2.0f;
         } else if (heightDiff > 2.0f) {
-            this->actor.world.pos.y = player->bodyPartsPos[PLAYER_ADULT_BODYPART_WAIST].y - 2.0f;
+            this->actor.world.pos.y = player->bodyPartsPos[bodyPartWaistIndex].y - 2.0f;
         }
         Matrix_Translate(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z, MTXMODE_NEW);
         Matrix_Scale(this->actor.scale.x, this->actor.scale.y, this->actor.scale.z, MTXMODE_APPLY);
@@ -245,17 +247,19 @@ void MagicDark_OrbDraw(Actor* thisx, PlayState* play) {
     Player* player = GET_PLAYER(play);
     s32 pad;
     f32 sp6C = play->state.frames & 0x1F;
+    s16 bodyPartLHandIndex = LINK_AGE_VALUE(PLAYER_ADULT_BODYPART_L_HAND, PLAYER_WOLF_BODYPART_L_PAD);
+    s16 bodyPartRHandIndex = LINK_AGE_VALUE(PLAYER_ADULT_BODYPART_R_HAND, PLAYER_WOLF_BODYPART_R_PAD);
 
     if (this->timer < 32) {
         pos.x =
-            (player->bodyPartsPos[(LINK_IS_ADULT ? PLAYER_ADULT_BODYPART_L_HAND : PLAYER_WOLF_BODYPART_L_PAD)].x + 
-            player->bodyPartsPos[(LINK_IS_ADULT ? PLAYER_ADULT_BODYPART_R_HAND : PLAYER_WOLF_BODYPART_R_PAD)].x) * 0.5f;
+            (player->bodyPartsPos[bodyPartLHandIndex].x +
+            player->bodyPartsPos[bodyPartRHandIndex].x) * 0.5f;
         pos.y =
-            (player->bodyPartsPos[(LINK_IS_ADULT ? PLAYER_ADULT_BODYPART_L_HAND : PLAYER_WOLF_BODYPART_L_PAD)].y + 
-            player->bodyPartsPos[(LINK_IS_ADULT ? PLAYER_ADULT_BODYPART_R_HAND : PLAYER_WOLF_BODYPART_R_PAD)].y) * 0.5f;
+            (player->bodyPartsPos[bodyPartLHandIndex].y +
+            player->bodyPartsPos[bodyPartRHandIndex].y) * 0.5f;
         pos.z =
-            (player->bodyPartsPos[(LINK_IS_ADULT ? PLAYER_ADULT_BODYPART_L_HAND : PLAYER_WOLF_BODYPART_L_PAD)].z + 
-            player->bodyPartsPos[(LINK_IS_ADULT ? PLAYER_ADULT_BODYPART_R_HAND : PLAYER_WOLF_BODYPART_R_PAD)].z) * 0.5f;
+            (player->bodyPartsPos[bodyPartLHandIndex].z +
+            player->bodyPartsPos[bodyPartRHandIndex].z) * 0.5f;
         if (this->timer > 20) {
             pos.y += (this->timer - 20) * 1.4f;
         }

--- a/src/overlays/actors/ovl_Shot_Sun/z_shot_sun.c
+++ b/src/overlays/actors/ovl_Shot_Sun/z_shot_sun.c
@@ -188,10 +188,11 @@ void ShotSun_UpdateHyliaSun(ShotSun* this, PlayState* play) {
     } else {
         if (!(this->actor.xzDistToPlayer > 120.0f) && gSaveContext.save.dayTime >= CLOCK_TIME(6, 30) &&
             gSaveContext.save.dayTime < CLOCK_TIME(7, 30)) {
-            cylinderPos.x = player->bodyPartsPos[(LINK_IS_ADULT ? PLAYER_ADULT_BODYPART_HEAD : PLAYER_WOLF_BODYPART_HEAD)].x + play->envCtx.sunPos.x * (1.0f / 6.0f);
+            s16 bodyPartHeadIndex = LINK_AGE_VALUE(PLAYER_ADULT_BODYPART_HEAD, PLAYER_WOLF_BODYPART_NECK);
+            cylinderPos.x = player->bodyPartsPos[bodyPartHeadIndex].x + play->envCtx.sunPos.x * (1.0f / 6.0f);
             cylinderPos.y =
-                player->bodyPartsPos[(LINK_IS_ADULT ? PLAYER_ADULT_BODYPART_HEAD : PLAYER_WOLF_BODYPART_HEAD)].y - 30.0f + play->envCtx.sunPos.y * (1.0f / 6.0f);
-            cylinderPos.z = player->bodyPartsPos[(LINK_IS_ADULT ? PLAYER_ADULT_BODYPART_HEAD : PLAYER_WOLF_BODYPART_HEAD)].z + play->envCtx.sunPos.z * (1.0f / 6.0f);
+                player->bodyPartsPos[bodyPartHeadIndex].y - 30.0f + play->envCtx.sunPos.y * (1.0f / 6.0f);
+            cylinderPos.z = player->bodyPartsPos[bodyPartHeadIndex].z + play->envCtx.sunPos.z * (1.0f / 6.0f);
 
             this->hitboxPos = cylinderPos;
 

--- a/src/overlays/effects/ovl_Effect_Ss_Fhg_Flash/z_eff_ss_fhg_flash.c
+++ b/src/overlays/effects/ovl_Effect_Ss_Fhg_Flash/z_eff_ss_fhg_flash.c
@@ -181,7 +181,7 @@ void EffectSsFhgFlash_UpdateShock(PlayState* play, u32 index, EffectSs* this) {
 
     if (this->rParam == FHGFLASH_SHOCK_PLAYER) {
         player = GET_PLAYER(play);
-        randBodyPart = Rand_ZeroFloat((LINK_IS_ADULT ? PLAYER_ADULT_BODYPART_MAX : PLAYER_WOLF_BODYPART_MAX) - 0.1f);
+        randBodyPart = Rand_ZeroFloat(PLAYER_BODYPART_MAX - 0.1f);
         this->pos.x = player->bodyPartsPos[randBodyPart].x + Rand_CenteredFloat(10.0f);
         this->pos.y = player->bodyPartsPos[randBodyPart].y + Rand_CenteredFloat(15.0f);
         this->pos.z = player->bodyPartsPos[randBodyPart].z + Rand_CenteredFloat(10.0f);


### PR DESCRIPTION
Add general 'LINK_AGE_VALUE' macro to replace the following pattern:
  LINK_IS_ADULT ? <adult> : <child>
Replace 'IS_LIMB' checks with more general 'LINK_AGE_VALUE' checks
  (since we'll likely want to duplicate/rewrite these blocks eventually
  once we figure out animations for wolf link).
Make almost every use of PLAYER_LIMB and PLAYER_BODYPART values use
  LINK_AGE_VALUE; added some TODOs if there was not an obvious value to
  pick, but we'll likely end up revisiting most of these anyway.
Add 'PLAYER_LIMB_MAX' and 'PLAYER_BODYPART_MAX' defines; use when you
  need to know the maximum valid value for the current age of link.
Add 'PLAYER_LIMB_ARR_COUNT' and 'PLAYER_BODYPART_ARR_COUNT' defines;
  use when you need to have an array be large enough to hold data for
  both adult and wolf link.
Small fix to animation data (correct frame count) of temp idle wolf
  link animation.